### PR TITLE
Workaround for the peek function

### DIFF
--- a/BinaryHeap.js
+++ b/BinaryHeap.js
@@ -148,7 +148,11 @@ BinaryHeap.prototype = {
     //      modifying the heap's data
     //-------------------------------------------------------------------------
     peek: function() {
-        return this._clone(this._data[0]);
+      //  return this._clone(this._data[0]);
+      // parse.stringify does actually make a deep copy and it works (i think) in all data types.
+      // 
+      var ret = JSON.parse(JSON.stringify(this._data[0]));
+      return ret;
     },
 
 


### PR DESCRIPTION
This would solve the problem of recursing deep into some types of objects. 
In the case of the mongoose object we had the problem with, it's a moot point anyway because even when the copy is a deep copy, any modification in the copy will modify the original (if saved to the DB, of course) because the _id of the object gets copied anyway. But this has nothing to do with the copy itself.
